### PR TITLE
Concurrent importing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ __pycache__/
 
 /dist/
 /tmp/
+
+import_log

--- a/src/commands/install.py
+++ b/src/commands/install.py
@@ -24,7 +24,9 @@ def run(args):
         for vm in config['virtual_machines']:
             vm_name = vm['name']
             ova_url = urljoin(ova_repo, vm['ova_filename'])
-            Utils.fetch_file(ova_url, os.path.join(ova_dir, f"{vm_name}.ova"))
+    
+            ova_file = os.path.join(ova_dir, f"{vm_name}.ova")
+            Utils.fetch_file(ova_url, ova_file, args.check_existing)
 
     print("\n=== IMPORTING VMS ===")
     for vm_name, filepath in Utils.find_files(ova_dir,".ova"):

--- a/src/commands/install.py
+++ b/src/commands/install.py
@@ -4,7 +4,8 @@ from urllib.parse import urljoin
 
 from src import configuration
 from src.utils.Utils import Utils
-from src.utils.VboxManagerAdapter import VboxManagerAdapter
+# from src.utils.VboxManagerAdapter import VboxManagerAdapter
+from src.utils.VboxManagerAdapter import ConcurrentImporter
 
 import threading
 
@@ -32,34 +33,22 @@ def run(args):
 
     print("\n=== IMPORTING VMS ===")
 
-    tasks = []
     for vm_name, filepath in Utils.find_files(ova_dir,".ova"):
         try:
             if os.path.exists(os.path.join(vms_dir, vm_name)):
                 print(f"{vm_name} already imported! Skipping...")
 
-            tasks.append([vm_name, threading.Thread(
-                        target=VboxManagerAdapter.import_vm,
-                        args=(filepath, vm_name, vms_dir))])
+            ConcurrentImporter.import_vm(filepath, vm_name, vms_dir)
 
         except Exception as e:
             print(f"\nError importing {vm_name}: {str(e)}")
 
-    for [name, thread] in tasks:
-        thread.start()
+    ConcurrentImporter.wait()
 
-    is_all_completed = False
-    while not is_all_completed:
-        for index, [name, thread] in enumerate(tasks):
-            if not thread.is_alive():
-                print("*** {:^60} ***".format(f"{name} finished importing!"))
-                del tasks[index]
-                break
-        if len(tasks) == 0:
-            is_all_completed = True
-            break
-
-        time.sleep(0.25)
-
+    for index, result in enumerate(ConcurrentImporter.results):
+        if result == False:
+            print("\nError importing {name}: {err}"
+                  .format(ConcurrentImporter.names[index],
+                          ConcurrentImporter.errors[index]))
 
     print("\nAll operations completed!")

--- a/src/commands/install.py
+++ b/src/commands/install.py
@@ -1,10 +1,12 @@
 import os
+import time
 from urllib.parse import urljoin
 
 from src import configuration
 from src.utils.Utils import Utils
 from src.utils.VboxManagerAdapter import VboxManagerAdapter
 
+import threading
 
 def run(args):
     Utils.print_cli_hello()
@@ -29,14 +31,35 @@ def run(args):
             Utils.fetch_file(ova_url, ova_file, args.check_existing)
 
     print("\n=== IMPORTING VMS ===")
+
+    tasks = []
     for vm_name, filepath in Utils.find_files(ova_dir,".ova"):
         try:
             if os.path.exists(os.path.join(vms_dir, vm_name)):
                 print(f"{vm_name} already imported! Skipping...")
 
-            if not VboxManagerAdapter.import_vm(filepath, vm_name, vms_dir):
-                print(f"\nError importing {vm_name}!")
+            tasks.append([vm_name, threading.Thread(
+                        target=VboxManagerAdapter.import_vm,
+                        args=(filepath, vm_name, vms_dir))])
 
         except Exception as e:
             print(f"\nError importing {vm_name}: {str(e)}")
+
+    for [name, thread] in tasks:
+        thread.start()
+
+    is_all_completed = False
+    while not is_all_completed:
+        for index, [name, thread] in enumerate(tasks):
+            if not thread.is_alive():
+                print("*** {:^60} ***".format(f"{name} finished importing!"))
+                del tasks[index]
+                break
+        if len(tasks) == 0:
+            is_all_completed = True
+            break
+
+        time.sleep(0.25)
+
+
     print("\nAll operations completed!")

--- a/src/parsers.py
+++ b/src/parsers.py
@@ -9,6 +9,12 @@ def add_install_parser(subparser):
         default=False,
         help='skip downloading OVA files (use local copies only)'
     )
+    install_parser.add_argument(
+            '--check-existing',
+            action='store_true',
+            default=False,
+            help='only download absent OVA files, do NOT update existing ones'
+    )
     install_parser.set_defaults(func=install.run)
 
 def add_startup_parser(subparser):

--- a/src/utils/Utils.py
+++ b/src/utils/Utils.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import requests
 from tqdm import tqdm
 
-
 class Utils:
     @staticmethod
     def print_cli_hello():
@@ -29,6 +28,7 @@ class Utils:
 
     @staticmethod
     def fetch_file(url: str, path: str, check_if_exists=False):
+
         if check_if_exists:
             if os.path.exists(path):
                 print(f"File {os.path.basename(path)} already exists! Skipping...")
@@ -42,13 +42,28 @@ class Utils:
             total_size = int(response.headers.get('content-length', 0))
             block_size = 8192
 
-            with open(path, 'wb') as f:
+            # instead of writing directly into file, we first write it into
+            # a temporary buffer and only if the download is completed
+            # successfully, we rename it afterwards.
+            # It allows us to determine which files are corrupted if download
+            # gets interrupted.
+            temp_path = f'{path}.tmp'
+            with open(temp_path, 'wb') as f:
                 with tqdm(total=total_size, unit='B', unit_scale=True, unit_divisor=1024) as pbar:
                     for chunk in response.iter_content(chunk_size=block_size):
                         f.write(chunk)
                         pbar.update(len(chunk))
+
+            os.rename(temp_path, path)
+
+        except KeyboardInterrupt as interrupt:
+            # (Andrew) TODO: add keyboard interruption handling
+            print("Download has been interrupted")
+            os.remove(temp_path)
+
         except Exception as e:
             print(f"\nError fetching url: {url}\n{str(e)}")
+            os.remove(temp_path)
 
     @staticmethod
     def find_files(directory: str, *extensions: str) -> list[tuple[str, str]]:

--- a/src/utils/VboxManagerAdapter.py
+++ b/src/utils/VboxManagerAdapter.py
@@ -1,4 +1,5 @@
 import subprocess
+import os
 from typing import Literal
 
 
@@ -15,7 +16,13 @@ class VboxManagerAdapter:
             "--basefolder", vms_dir
         ]
 
-        process = subprocess.Popen(cmd)
+        if not os.path.exists('import_log'):
+            os.makedirs('import_log')
+
+        log_file_name = os.path.join('import_log', f'{vm_name}.log')
+        log_file = open(log_file_name, "w")
+
+        process = subprocess.Popen(cmd, stdout=log_file, stderr=log_file)
         process.wait()
 
         return process.returncode == 0

--- a/src/utils/VboxManagerAdapter.py
+++ b/src/utils/VboxManagerAdapter.py
@@ -1,7 +1,62 @@
 import subprocess
+import threading
 import os
+import time
+
 from typing import Literal
 
+class ConcurrentImporter:
+    results = [None] * 100
+    errors = [None] * 100
+    names = [None] * 100
+    tasks = [None] * 100
+
+    count = 0
+
+    @staticmethod
+    def import_vm(ova_path: str, vm_name: str, vms_dir: str) -> bool:
+        id = ConcurrentImporter.count
+        ConcurrentImporter.count += 1
+        def handler(ova_paht, vm_name, vms_dir):
+            try:
+                VboxManagerAdapter.import_vm(ova_path, vm_name, vms_dir)
+            except Exception as e:
+                results[id] = False
+                errors[id] = e
+            else:
+                results[id] = True
+            finally:
+                return
+
+        thread = threading.Thread(target=handler,
+                         args=(ova_path, vm_name, vms_dir))
+        ConcurrentImporter.names[id] = vm_name
+        ConcurrentImporter.tasks[id] = thread
+        ConcurrentImporter.tasks[id].start()
+
+    @staticmethod
+    def wait():
+        # removing empty stuff
+        ConcurrentImporter.results = list(filter((None).__ne__, ConcurrentImporter.results))
+        ConcurrentImporter.names = list(filter((None).__ne__, ConcurrentImporter.names))
+        ConcurrentImporter.tasks = list(filter((None).__ne__, ConcurrentImporter.tasks))
+
+        name_buf = ConcurrentImporter.names
+        task_buf = ConcurrentImporter.tasks
+        while ConcurrentImporter.count != 0:
+            for index, task in enumerate(ConcurrentImporter.tasks):
+                if task.is_alive() == False:
+                    print("*** {:^60} ***".format(f"{ConcurrentImporter.names[index]} finished importing!"))
+                    del ConcurrentImporter.tasks[index]
+                    del ConcurrentImporter.names[index]
+                    ConcurrentImporter.count -= 1
+                    break
+
+                # so we don't use CPU for nothing
+                time.sleep(0.25)
+                   
+        ConcurrentImporter.names = name_buf
+        ConcurrentImporter.tasks = task_buf
 
 class VboxManagerAdapter:
     @staticmethod


### PR DESCRIPTION
# Concurrent importing

---

Importing virtual machines takes too much time, so why not use a couple more threads to speed it up?

If you are importing `n` machines, `n` threads will be created.
Each thread starts `1` process of `VBoxManage` which, in turn, copies the machine.

---

> Note: `VBoxManage` output is now stored in `import_log/[name].log` so interface looks neat and clean.

> Note: Downloads are now saved in .tmp file until they are fully finished to avoid confusion in case it's interrupted.